### PR TITLE
Filters for enqueue AJAXQueue

### DIFF
--- a/ajax-queue.php
+++ b/ajax-queue.php
@@ -3,7 +3,7 @@
 Plugin Name:	AJAX Queue
 Description:	Group AJAX calls
 Author:		    Modern Tribe
-Version:	    1.0.0
+Version:	    1.0.1
 Author URI:	    http://www.tri.be
 */
 

--- a/src/AJAXQueue/Resources.php
+++ b/src/AJAXQueue/Resources.php
@@ -23,7 +23,15 @@ class Resources {
 	 */
 	public function __construct( $action ) {
 		$this->action = $action;
-		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue' ] );
+		$this->enqueue_scripts();
+	}
+
+	public function enqueue_scripts() {
+		$ajaxq_public = apply_filters( 'ajaxq-public', true );
+		$ajaxq_admin  = apply_filters( 'ajaxq-admin', false );
+
+		if( $ajaxq_public ) add_action( 'wp_enqueue_scripts', [ $this, 'enqueue' ] );
+		if( $ajaxq_admin ) add_action( 'admin_enqueue_scripts', [ $this, 'enqueue' ] );
 	}
 
 	/**


### PR DESCRIPTION
Allows to use AJAXQueue in admin

Usage:
`add_filter( 'ajaxq-public', function(){ return false; } );`
`add_filter( 'ajaxq-admin', function(){ return true; }  );`